### PR TITLE
fix(actions): Mirror README on merged PRs to main #12

### DIFF
--- a/.github/workflows/github_workflows_sync-gist-readme.yml
+++ b/.github/workflows/github_workflows_sync-gist-readme.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.base.ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   sync:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true


### PR DESCRIPTION
## Summary
- run the Gist sync workflow when a pull request is merged into `main`
- keep manual dispatch available
- check out the merge commit SHA so the mirrored README matches what landed on `main`

Closes #12
