### PR TITLE
fix(actions): Skip README sync without GIST_TOKEN #14

### DIFF
--- a/.github/workflows/github_workflows_sync-gist-readme.yml
+++ b/.github/workflows/github_workflows_sync-gist-readme.yml
@@ -30,6 +30,9 @@ jobs:
 
       - name: Mirror README to Gist if changed
         env:
+          # Setup:
+          # 1. Create a classic PAT with only `gist` scope: https://github.com/settings/tokens/new
+          # 2. Store it as this repo's Actions secret: `gh secret set GIST_TOKEN --repo mathemage/mathemage`
           GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- skip the README-to-Gist sync cleanly when `GIST_TOKEN` is not configured
- emit a GitHub Actions notice instead of failing the workflow
- preserve the existing Gist update behavior when the secret is present

Closes #14
