### PR TITLE
docs(readme): Split Vibe Engineering Projects by Type #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Full profile: [github.com/mathemage](https://github.com/mathemage)
 ## 🤖 Vibe Engineering Projects
 > Sorted latest first.
 
-### Client Projects
+### 🤝 Client Projects
 - [preference-model-initial-assessment](https://github.com/mathemage/preference-model-initial-assessment) — RL-style Llama decoder block assessment with scratch-built RMSNorm, RoPE, GQA, and SwiGLU plus automated judge/test validation [Python, PyTorch, pytest, GitHub Actions]
 - [mindwell-assignment-ai-engineer-2026](https://github.com/mathemage/mindwell-assignment-ai-engineer-2026) — production-ready CBT assistant MVP with cited RAG answers, multi-agent safety checks, and privacy controls [Python, FastAPI, PostgreSQL]
 - [mindwell-assignment-2026](https://github.com/mathemage/mindwell-assignment-2026) — AI CBT assistant MVP with RAG, safety guardrails, privacy-first handling, and evaluation tooling [Python, FastAPI, PostgreSQL]
 - [tv-nova-ai-assignment-2026](https://github.com/mathemage/tv-nova-ai-assignment-2026) — TV audience share forecasting pipeline with EDA, deep-learning models, and Dockerized prediction service [Python, PyTorch, FastAPI]
 - [scio-assignment-2026](https://github.com/mathemage/scio-assignment-2026) — real-time student progress monitor with teacher/student roles, QR group joining, and chat-based tracking [Python, FastAPI, React]
 
-### Personal Projects
+### 🧪 Personal Projects
 - [boulder-daddy](https://github.com/mathemage/boulder-daddy) — professional bouldering coaching website with service details, pricing, booking, testimonials, contact form, and Instagram integration [Next.js, Tailwind CSS]
 
 ## 📚 Publications, Presentations, Talks


### PR DESCRIPTION
## Summary
- split the `Vibe Engineering Projects` section into `Client Projects` and `Personal Projects`
- keep the `Sorted latest first.` note at the top of the section
- add `boulder-daddy` under the personal subsection

Closes #20
