### PR TITLE
docs(readme): Append deep-workflow to Personal Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Full profile: [github.com/mathemage](https://github.com/mathemage)
 
 ### 🧪 Personal Projects
 - [boulder-daddy](https://github.com/mathemage/boulder-daddy) — professional [bouldering coaching website](https://boulder-daddy.vercel.app/) with service details, pricing, booking, testimonials, contact form, and Instagram integration [Next.js, Tailwind CSS]
-- [deep-workflow](https://github.com/mathemage/deep-workflow)
+- [deep-workflow](https://github.com/mathemage/deep-workflow) — hosted deep-work planner for synced 45-minute focus sessions across laptops and phones [Django, PostgreSQL, HTMX, Alpine.js, Tailwind CSS]
 
 ## 📚 Publications, Presentations, Talks
 - [endgames-master-thesis](https://github.com/mathemage/endgames-master-thesis) — MSc thesis on combinatorial game theory endgames


### PR DESCRIPTION
Closes #26\n\n## Summary\n- append https://github.com/mathemage/deep-workflow to the README Personal Projects section\n