### PR TITLE
[codex] Add SleepOps to personal projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Full profile: [github.com/mathemage](https://github.com/mathemage)
 - [deep-workflow](https://github.com/mathemage/deep-workflow) — hosted deep-work planner for synced 45-minute focus sessions across laptops and phones [Django, PostgreSQL, HTMX, Alpine.js, Tailwind CSS]
 - [adhd-cockpit](https://github.com/mathemage/adhd-cockpit) — production-ready multi-device-synced ADHD web app with dynamic UI and real backend intelligence [Django, HTMX]
 - [noema-forge](https://github.com/mathemage/noema-forge) — journaling web app for turning raw thoughts into clearer, searchable reflections [Node.js, Python, Markdown]
+- [SleepOps](https://github.com/mathemage/SleepOps) — constraint-driven sleep operating system that turns work schedules, morning routines, and shutdown deadlines into protected sleep rules [Next.js, React, TypeScript, Tailwind CSS, PWA, Vitest, Playwright, GitHub Actions]
 
 ## 📚 Publications, Presentations, Talks
 - [endgames-master-thesis](https://github.com/mathemage/endgames-master-thesis) — MSc thesis on combinatorial game theory endgames


### PR DESCRIPTION
## Summary
- Append SleepOps to the README Personal Projects section.
- Use the same one-line project format as neighboring entries.
- Base the description and technology list on the SleepOps repository files and metadata.

Closes #36.

## Validation
- `git diff --check`
- Reviewed the README diff for minimal scope and format consistency.
- Verified the SleepOps repository metadata and files for the listed technologies.