### PR TITLE
docs(readme): Add gem-github-hooks to Client Projects #40

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Full profile: [github.com/mathemage](https://github.com/mathemage)
 > Sorted latest first.
 
 ### 🤝 Client Projects
+- [gem-github-hooks](https://github.com/mathemage/gem-github-hooks) — standalone catalog of 30 GitHub Actions workflow examples for modern C# and ASP.NET Core repositories [YAML, GitHub Actions, C#, .NET, ASP.NET Core]
 - [abugo-loom-2026](https://github.com/mathemage/abugo-loom-2026) — Abugo job assignment repo with task brief, notes, and deliverables [Python, Markdown]
 - [preference-model-initial-assessment](https://github.com/mathemage/preference-model-initial-assessment) — RL-style Llama decoder block assessment with scratch-built RMSNorm, RoPE, GQA, and SwiGLU plus automated judge/test validation [Python, PyTorch, pytest, GitHub Actions]
 - [mindwell-assignment-ai-engineer-2026](https://github.com/mathemage/mindwell-assignment-ai-engineer-2026) — production-ready CBT assistant MVP with cited RAG answers, multi-agent safety checks, and privacy controls [Python, FastAPI, PostgreSQL]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Full profile: [github.com/mathemage](https://github.com/mathemage)
 > Sorted latest first.
 
 ### 🤝 Client Projects
-- [gem-github-hooks](https://github.com/mathemage/gem-github-hooks) — standalone catalog of 30 GitHub Actions workflow examples for modern C# and ASP.NET Core repositories [YAML, GitHub Actions, C#, .NET, ASP.NET Core]
+- [gem-github-hooks](https://github.com/mathemage/gem-github-hooks) — Standalone catalog of 30 GitHub Actions workflows for modern C# and ASP.NET Core repositories [YAML, GitHub Actions, C#, .NET, ASP.NET Core]
 - [abugo-loom-2026](https://github.com/mathemage/abugo-loom-2026) — Abugo job assignment repo with task brief, notes, and deliverables [Python, Markdown]
 - [preference-model-initial-assessment](https://github.com/mathemage/preference-model-initial-assessment) — RL-style Llama decoder block assessment with scratch-built RMSNorm, RoPE, GQA, and SwiGLU plus automated judge/test validation [Python, PyTorch, pytest, GitHub Actions]
 - [mindwell-assignment-ai-engineer-2026](https://github.com/mathemage/mindwell-assignment-ai-engineer-2026) — production-ready CBT assistant MVP with cited RAG answers, multi-agent safety checks, and privacy controls [Python, FastAPI, PostgreSQL]


### PR DESCRIPTION
Prepend the new project repository https://github.com/mathemage/gem-github-hooks to the 🤝 Client Projects section with a brief description and tech stack in the style of existing entries.